### PR TITLE
Remove duplication introduced by libdrm 2.4.104

### DIFF
--- a/libweston/backend-drm/drm-gbm.c
+++ b/libweston/backend-drm/drm-gbm.c
@@ -298,7 +298,7 @@ drm_output_render_gl(struct drm_output_state *state, pixman_region32_t *damage)
 	struct drm_fb *ret;
 	struct weston_head *w_head = weston_output_get_first_head(&output->base);
 	struct drm_head *head = to_drm_head(w_head);
-	struct drm_hdr_metadata_static *dmd = &head->color_state.o_md;
+	struct hdr_metadata_infoframe *dmd = &head->color_state.o_md;
 	uint32_t target_cs = drm_cs_to_weston_cs(head->color_state.o_cs);
 	struct weston_hdr_metadata whm = {0};
 	struct weston_renderer *renderer = output->base.compositor->renderer;

--- a/libweston/backend-drm/drm-internal.h
+++ b/libweston/backend-drm/drm-internal.h
@@ -45,6 +45,7 @@
 
 #include <xf86drm.h>
 #include <xf86drmMode.h>
+#include <drm.h>
 #include <drm_fourcc.h>
 
 #ifdef BUILD_DRM_GBM
@@ -519,36 +520,13 @@ enum drm_colorspace {
 	DRM_COLORSPACE_MAX,
 };
 
-/* Static HDR metadata to be sent to kernel, matches kernel structure */
-struct drm_hdr_metadata_static {
-	uint8_t eotf;
-	uint8_t metadata_type;
-	struct {
-		uint16_t x, y;
-	} display_primaries[3];
-	struct {
-		uint16_t x, y;
-	} white_point;
-	uint16_t max_display_mastering_luminance;
-	uint16_t min_display_mastering_luminance;
-	uint16_t max_cll;
-	uint16_t max_fall;
-};
-
-struct hdr_output_metadata {
-	uint32_t metadata_type;
-	union {
-		struct drm_hdr_metadata_static static_md;
-	};
-};
-
 /* Connector's color correction status */
 struct drm_conn_color_state {
 	bool changed;
 	uint8_t o_cs;
 	uint8_t o_eotf;
 	uint32_t hdr_md_blob_id;
-	struct drm_hdr_metadata_static o_md;
+	struct hdr_metadata_infoframe o_md;
 };
 
 struct drm_head {

--- a/libweston/backend-drm/state-propose.c
+++ b/libweston/backend-drm/state-propose.c
@@ -1041,7 +1041,7 @@ static void
 drm_prepare_output_hdr_metadata(struct drm_backend *b,
 				struct drm_head *head,
 				struct weston_hdr_metadata *surface_md,
-				struct drm_hdr_metadata_static *out_md)
+				struct hdr_metadata_infoframe *out_md)
 {
 	struct weston_hdr_metadata_static *c_md;
 	struct drm_edid_hdr_metadata_static *d_md;
@@ -1087,7 +1087,7 @@ drm_head_prepare_hdr_metadata_blob(struct drm_backend *b,
 					hdr_surf->hdr_metadata,
 					&target->o_md);
 
-	memcpy(&output_metadata.static_md, &target->o_md, sizeof (target->o_md));
+	memcpy(&output_metadata.hdmi_metadata_type1, &target->o_md, sizeof (target->o_md));
 
 	/* create blob to be set during next commit */
 	ret = drmModeCreatePropertyBlob(b->drm.fd,

--- a/meson.build
+++ b/meson.build
@@ -144,7 +144,7 @@ dep_libinput = dependency('libinput', version: '>= 0.8.0')
 dep_libevdev = dependency('libevdev')
 dep_libm = cc.find_library('m')
 dep_libdl = cc.find_library('dl')
-dep_libdrm = dependency('libdrm', version: '>= 2.4.86')
+dep_libdrm = dependency('libdrm', version: '>= 2.4.104')
 dep_libdrm_headers = dep_libdrm.partial_dependency(compile_args: true)
 dep_threads = dependency('threads')
 


### PR DESCRIPTION
New libdrm introduces duplication of some of HDR related structures. Removing redundant structures from weston code and also increasing version number increase of libdrm needed for weston build 