### PR TITLE
compositor-drm: Destroy any HDR metadata along with surface

### DIFF
--- a/libweston/compositor.c
+++ b/libweston/compositor.c
@@ -2238,6 +2238,9 @@ weston_surface_destroy(struct weston_surface *surface)
 
 	weston_presentation_feedback_discard_list(&surface->feedback_list);
 
+	if(surface->hdr_surface_resource)
+		wl_resource_destroy(surface->hdr_surface_resource);
+
 	wl_list_for_each_safe(constraint, next_constraint,
 			      &surface->pointer_constraints,
 			      link)


### PR DESCRIPTION
Without this change, destroy_hdr_surface isn't called until after the weston_surface has been destroyed and accesses memory which has been freed.